### PR TITLE
Package fix for BaratineMojo

### DIFF
--- a/baratine-maven-plugin/src/main/java/com/caucho/maven/BaratineMojo.java
+++ b/baratine-maven-plugin/src/main/java/com/caucho/maven/BaratineMojo.java
@@ -180,7 +180,7 @@ public class BaratineMojo extends BaratineBaseMojo
     command.add(javaHome + "/bin/java");
     command.add("-cp");
     command.add(cp);
-    command.add("com.caucho.cli.baratine.BaratineCommandLine");
+    command.add("com.caucho.v5.cli.baratine.BaratineCommandLine");
 
     command.add("package");
     command.add("-o");


### PR DESCRIPTION
…the CLI) to be in a ".v5." package heirarchy. This corrects the package for the CLI.
